### PR TITLE
feat: automate githubaction update

### DIFF
--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -25,8 +25,7 @@ policies:
     values:
       - updatecli/values.d/scm.yaml
   - name: Sync Updatecli values files from github.com/updatecli/updatecli
-    policy: ghcr.io/updatecli/policies/file:0.2.0
+    policy: ghcr.io/updatecli/policies/file:0.2.0@sha256:d520c1dec77a5414fb294df41b6bfc9efb11dcb1fc4bfa83f01314e24a0d6431
     values:
       - updatecli/values.d/scm.yaml
       - updatecli/values.d/sync.yaml
-

--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -6,26 +6,38 @@ policies:
     policy: ghcr.io/updatecli/policies/updatecli/autodiscovery:0.5.0@sha256:947817644fb89e27f7b7121b822328c2d47364c7a3a08241e4d2ac1a5897020c
     values:
       - updatecli/values.d/scm.yaml
+
   - name: Golang Version
     policy: ghcr.io/updatecli/policies/golang/version:0.4.0@sha256:9b3c09a73ffbecc690f07a4a44244f51dcc1dfb0e5a292207f2543b79f08fcaa
     values:
       - updatecli/values.d/scm.yaml
+
   - name: Minor Golang Module update
     policy: ghcr.io/updatecli/policies/autodiscovery/golang:0.10.0@sha256:3b1a2b03b3cd8e33305ca165a8be2ca126a06be4cbdf388bf98e48a568855cdc
     values:
       - updatecli/values.d/scm.yaml
       - updatecli/values.d/golang_minor.yaml
+
   - name: Patch Golang Module update
     policy: ghcr.io/updatecli/policies/autodiscovery/golang:0.10.0@sha256:3b1a2b03b3cd8e33305ca165a8be2ca126a06be4cbdf388bf98e48a568855cdc
     values:
       - updatecli/values.d/scm.yaml
       - updatecli/values.d/golang_patch.yaml
+
   - name: Update golangci-lint
     policy: ghcr.io/updatecli/policies/golangci-lint/githubaction:0.5.0@sha256:0e1addae151528a2c337a306eb323332dd36a91f36b0e93891858eed7466456b
     values:
       - updatecli/values.d/scm.yaml
+
   - name: Sync Updatecli values files from github.com/updatecli/updatecli
     policy: ghcr.io/updatecli/policies/file:0.2.0@sha256:d520c1dec77a5414fb294df41b6bfc9efb11dcb1fc4bfa83f01314e24a0d6431
     values:
       - updatecli/values.d/scm.yaml
       - updatecli/values.d/sync.yaml
+
+  - name: Update githubactions
+    policy: ghcr.io/updatecli/policies/autodiscovery/githubaction:0.1.0@sha256:ddac4fc192800a65e9a92669600db3eb66fe442610073d34202513b265ba7b29
+    values:
+      - updatecli/values.d/scm.yaml
+      - updatecli/values.d/githubaction.yaml
+

--- a/updatecli/values.d/githubaction.yaml
+++ b/updatecli/values.d/githubaction.yaml
@@ -1,0 +1,3 @@
+spec:
+  digest: true
+  rootdir: '.github'

--- a/updatecli/values.d/sync.yaml
+++ b/updatecli/values.d/sync.yaml
@@ -9,6 +9,8 @@ files:
     dst: updatecli/values.d/golang_minor.yaml
   - src: updatecli/values.d/golang_patch.yaml
     dst: updatecli/values.d/golang_patch.yaml
+  - src: updatecli/values.d/githubaction.yaml
+    dst: updatecli/values.d/githubaction.yaml
 
 pr:
   automerge: true


### PR DESCRIPTION
Automate GitHub action version update and sync the updatecli policy configuration from github.com/updatecli/updatecli