### PR TITLE
fix: bump Ubuntu runners to 24.04

### DIFF
--- a/.github/workflows/add_issue_to_project.yaml
+++ b/.github/workflows/add_issue_to_project.yaml
@@ -1,3 +1,4 @@
+---
 name: Add issues to Updatecli project
 on:
   issues:
@@ -6,7 +7,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to Updatecli project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       # https://github.com/actions/setup-go
       - name: Set up Go

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,3 +1,4 @@
+---
 name: Release Drafter
 on:
   workflow_dispatch:
@@ -7,7 +8,7 @@ on:
       - main
 jobs:
   update_release_draft:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:

--- a/.github/workflows/release-sandbox.yaml
+++ b/.github/workflows/release-sandbox.yaml
@@ -10,7 +10,7 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
       DOCKER_BUILDKIT: 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions:
   packages: write
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
       DOCKER_BUILDKIT: 1

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -4,7 +4,7 @@ permissions: {}
 jobs:
   run:
     name: Spell Check with Typos
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -9,7 +9,7 @@ on:
     - cron: '0 * * * *'
 jobs:
   updatecli:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2


### PR DESCRIPTION
Update Ubuntu runners version

## Description

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
